### PR TITLE
chore(ci): Fix setup-java actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v3
         with:
           distribution: oracle
           java-version: 21


### PR DESCRIPTION
The `setup-java` action is taking 3 mins to complete in v4. Reverting to v3 for the moment to solve the issue.

Tracked by: https://github.com/actions/setup-java/issues/596